### PR TITLE
Step3. ResultService: handles many results

### DIFF
--- a/src/main/scala/io/ubilab/result/model/Result.scala
+++ b/src/main/scala/io/ubilab/result/model/Result.scala
@@ -3,7 +3,7 @@ package io.ubilab.result.model
 import java.util.Date
 
 case class EventResult(
-    id:        String, // created | received | seen
+    id:        String, // created | received | seen | unseen
     idOwner:   Int,
     createdAt: Date
 )
@@ -11,6 +11,6 @@ case class EventResult(
 case class Result(id:              Int,
                   idOwner:         Int,
                   idRecipients:    List[Int],
-                  isSeen:          Boolean,
+                  var isSeen:          Boolean, // var hurts
                   eventResults:    List[EventResult],
                   contentOfResult: String)

--- a/src/main/scala/io/ubilab/result/service/ResultService.scala
+++ b/src/main/scala/io/ubilab/result/service/ResultService.scala
@@ -8,7 +8,12 @@ import scala.util.{Try,Success,Failure}
 class ResultService {
   private val results_store = ListBuffer[Result]()
 
-  def addResult(result:Result): Try[ListBuffer[Result]] = Try(results_store += result)
+  def addResult(result:Result): Try[ListBuffer[Result]] = Try {
+    results_store.exists(_.id == result.id) match {
+      case true => throw new IllegalArgumentException("A result already exists with the same id.")
+      case false => results_store += result
+    }
+  }
 
 
   def seenResult(idResult:Int) =

--- a/src/main/scala/io/ubilab/result/service/ResultService.scala
+++ b/src/main/scala/io/ubilab/result/service/ResultService.scala
@@ -23,7 +23,8 @@ class ResultService {
   def getAllResultSeen:List[Result] =
     results_store.filter(_.isSeen).toList
 
-  def getAllResultUnSeen:List[Result] = ???
+  def getAllResultUnSeen:List[Result] =
+    results_store.filter(!_.isSeen).toList
 
   def numberOfEventSeen:Int =  ???
 }

--- a/src/main/scala/io/ubilab/result/service/ResultService.scala
+++ b/src/main/scala/io/ubilab/result/service/ResultService.scala
@@ -22,7 +22,11 @@ class ResultService {
       case None =>
     }
 
-  def unseenResult(idResult:Int) = ???
+  def unseenResult(idResult:Int) =
+    results_store.find(_.id==idResult) match {
+      case Some(value) => value.isSeen= false
+      case None =>
+    }
 
   def getAllResult:List[Result] = results_store.toList
 

--- a/src/main/scala/io/ubilab/result/service/ResultService.scala
+++ b/src/main/scala/io/ubilab/result/service/ResultService.scala
@@ -5,18 +5,24 @@ import io.ubilab.result.model.Result
 import scala.collection.mutable.ListBuffer
 
 class ResultService {
-  val results_store = ListBuffer[Result]()
+  private val results_store = ListBuffer[Result]()
 
   def addResult(result:Result) = results_store += result
 
 
-  def seenResult(idResult:Int) = ???
+  def seenResult(idResult:Int) =
+    results_store.find(_.id==idResult) match {
+      case Some(value) => value.isSeen= true
+      case None =>
+    }
 
   def unseenResult(idResult:Int) = ???
 
   def getAllResult():List[Result] = results_store.toList
 
-  def getAllResultSeen():List[Result] = ???
+  def getAllResultSeen():List[Result] =
+    results_store.filter(_.isSeen).toList
+
   def getAllResultUnSeen():List[Result] = ???
 
   def numberOfEventSeen:Int =  ???

--- a/src/main/scala/io/ubilab/result/service/ResultService.scala
+++ b/src/main/scala/io/ubilab/result/service/ResultService.scala
@@ -3,11 +3,12 @@ package io.ubilab.result.service
 import io.ubilab.result.model.Result
 
 import scala.collection.mutable.ListBuffer
+import scala.util.{Try,Success,Failure}
 
 class ResultService {
   private val results_store = ListBuffer[Result]()
 
-  def addResult(result:Result) = results_store += result
+  def addResult(result:Result): Try[ListBuffer[Result]] = Try {results_store += result}
 
 
   def seenResult(idResult:Int) =

--- a/src/main/scala/io/ubilab/result/service/ResultService.scala
+++ b/src/main/scala/io/ubilab/result/service/ResultService.scala
@@ -18,12 +18,12 @@ class ResultService {
 
   def unseenResult(idResult:Int) = ???
 
-  def getAllResult():List[Result] = results_store.toList
+  def getAllResult:List[Result] = results_store.toList
 
-  def getAllResultSeen():List[Result] =
+  def getAllResultSeen:List[Result] =
     results_store.filter(_.isSeen).toList
 
-  def getAllResultUnSeen():List[Result] = ???
+  def getAllResultUnSeen:List[Result] = ???
 
   def numberOfEventSeen:Int =  ???
 }

--- a/src/main/scala/io/ubilab/result/service/ResultService.scala
+++ b/src/main/scala/io/ubilab/result/service/ResultService.scala
@@ -2,17 +2,19 @@ package io.ubilab.result.service
 
 import io.ubilab.result.model.Result
 
+import scala.collection.mutable.ListBuffer
+
 class ResultService {
+  val results_store = ListBuffer[Result]()
 
-
-  def addResult(result:Result) = ???
+  def addResult(result:Result) = results_store += result
 
 
   def seenResult(idResult:Int) = ???
 
   def unseenResult(idResult:Int) = ???
 
-  def getAllResult():List[Result] = List()
+  def getAllResult():List[Result] = results_store.toList
 
   def getAllResultSeen():List[Result] = ???
   def getAllResultUnSeen():List[Result] = ???

--- a/src/main/scala/io/ubilab/result/service/ResultService.scala
+++ b/src/main/scala/io/ubilab/result/service/ResultService.scala
@@ -8,7 +8,7 @@ import scala.util.{Try,Success,Failure}
 class ResultService {
   private val results_store = ListBuffer[Result]()
 
-  def addResult(result:Result): Try[ListBuffer[Result]] = Try {results_store += result}
+  def addResult(result:Result): Try[ListBuffer[Result]] = Try(results_store += result)
 
 
   def seenResult(idResult:Int) =

--- a/src/test/scala/io/ubilab/result/service/ResultServiceSpec.scala
+++ b/src/test/scala/io/ubilab/result/service/ResultServiceSpec.scala
@@ -51,28 +51,30 @@ class ResultServiceSpec extends FunSpec with Matchers {
 
     // init le service avec 3 résultats
     val resultService = ResultService.build
-    val a_result = Result(46, 76, List(42), false, Nil, "test")
-    resultService.addResult(a_result)
-    resultService.addResult(a_result.copy(id = a_result.id + 1))
-    resultService.addResult(a_result.copy(id = a_result.id + 2))
+    val result_1 = Result(46, 76, List(42), false, Nil, "test")
+    val result_2 = result_1.copy(id = result_1.id + 1)
+    val result_3 = result_1.copy(id = result_1.id + 2)
+    resultService.addResult(result_1)
+    resultService.addResult(result_2)
+    resultService.addResult(result_3)
 
     it("devrait avoir une liste de 3 résultats non vus après l'ajout de 3 résultats.") {
       resultService.getAllResultUnSeen.length shouldEqual 3
     }
 
     it("ne devrait pas autoriser l'ajout d'un résultat avec un id existant") {
-      resultService.addResult(a_result.copy(id = a_result.id)) shouldBe a[Failure[_]] // sameness of id is explicit!
+      resultService.addResult(result_1.copy(id = result_1.id)) shouldBe a[Failure[_]] // sameness of id is explicit!
     }
 
     it("devrait avoir 1 résultat vu dans la liste après la vision d'un résultat") {
-      resultService.seenResult(46)
+      resultService.seenResult(result_1.id)
       resultService.getAllResultSeen.length shouldEqual 1
     }
 
     it("devrait avoir les 3 résultats vus dans la liste après qu'ils soient tous vus.") {
-      resultService.seenResult(46)
-      resultService.seenResult(47)
-      resultService.seenResult(48)
+      resultService.seenResult(result_1.id)
+      resultService.seenResult(result_2.id)
+      resultService.seenResult(result_3.id)
       resultService.getAllResultSeen.length shouldEqual 3
     }
 

--- a/src/test/scala/io/ubilab/result/service/ResultServiceSpec.scala
+++ b/src/test/scala/io/ubilab/result/service/ResultServiceSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.{FunSpec, Matchers}
 
 class ResultServiceSpec extends FunSpec with Matchers {
 
-  describe("Step 1 : initialisation du projet avec 0 et 1 resultat") {
+  describe("Step 1 : initialisation du projet avec 0 et 1 résultat") {
 
     val resultService = ResultService.build
 
@@ -30,16 +30,16 @@ class ResultServiceSpec extends FunSpec with Matchers {
       )
     )
 
-    it("devrait avoir une liste de 1 résultat non vue") {
+    it("devrait avoir une liste de 1 résultat non vu") {
 
       resultService.getAllResult.length shouldEqual 1
 
     }
 
-    it("devrait avoir une liste de 1 résultat vue aprés la vision de ce résultat") {
+    it("devrait avoir une liste de 1 résultat vu après la vision de ce résultat") {
       resultService.seenResult(46)
-      resultService.getAllResultSeen().length shouldEqual 1
-      resultService.getAllResult().head.isSeen shouldEqual true
+      resultService.getAllResultSeen.length shouldEqual 1
+      resultService.getAllResult.head.isSeen shouldEqual true
     }
 
   }

--- a/src/test/scala/io/ubilab/result/service/ResultServiceSpec.scala
+++ b/src/test/scala/io/ubilab/result/service/ResultServiceSpec.scala
@@ -46,8 +46,15 @@ class ResultServiceSpec extends FunSpec with Matchers {
 
   describe("Après l'ajout de 3 résultats,") {
 
-    it("devrait avoir une liste de 3 resultats non vue aprés l'ajout de 3 resultat.") {
-      true shouldEqual false
+    // init le service avec 3 résultats
+    val resultService = ResultService.build
+    val a_result = Result(46, 76, List(42), false, Nil, "test")
+    resultService.addResult(a_result)
+    resultService.addResult(a_result.copy(id = a_result.id + 1))
+    resultService.addResult(a_result.copy(id = a_result.id + 2))
+
+    it("devrait avoir une liste de 3 résultats non vus après l'ajout de 3 résultats.") {
+      resultService.getAllResultUnSeen.length shouldEqual 3
     }
 
     it("ne devrait pas autoriser l'ajout d'un résultats avec un id existant") {

--- a/src/test/scala/io/ubilab/result/service/ResultServiceSpec.scala
+++ b/src/test/scala/io/ubilab/result/service/ResultServiceSpec.scala
@@ -3,6 +3,9 @@ package io.ubilab.result.service
 import io.ubilab.result.model.Result
 import org.scalatest.{FunSpec, Matchers}
 
+import scala.collection.mutable.ListBuffer
+import scala.util.{Failure, Success, Try}
+
 class ResultServiceSpec extends FunSpec with Matchers {
 
   describe("Step 1 : initialisation du projet avec 0 et 1 résultat") {
@@ -57,9 +60,8 @@ class ResultServiceSpec extends FunSpec with Matchers {
       resultService.getAllResultUnSeen.length shouldEqual 3
     }
 
-    it("ne devrait pas autoriser l'ajout d'un résultats avec un id existant") {
-      pending
-      true shouldEqual false
+    it("ne devrait pas autoriser l'ajout d'un résultat avec un id existant") {
+      resultService.addResult(a_result.copy(id = a_result.id)) shouldBe a[Failure[ListBuffer[Result]]]
     }
 
     it("devrait avoir 1 résultats vue dans la liste après la vision d'un résultat") {

--- a/src/test/scala/io/ubilab/result/service/ResultServiceSpec.scala
+++ b/src/test/scala/io/ubilab/result/service/ResultServiceSpec.scala
@@ -16,7 +16,6 @@ class ResultServiceSpec extends FunSpec with Matchers {
   }
 
   describe("Après l'ajout d'un résultat,") {
-    pending
 
     val resultService = ResultService.build
 
@@ -38,7 +37,7 @@ class ResultServiceSpec extends FunSpec with Matchers {
     }
 
     it("devrait avoir une liste de 1 résultat vue aprés la vision de ce résultat") {
-
+      pending
       resultService.seenResult(46)
       resultService.getAllResultSeen().length shouldEqual 1
       resultService.getAllResult().head.isSeen shouldEqual true

--- a/src/test/scala/io/ubilab/result/service/ResultServiceSpec.scala
+++ b/src/test/scala/io/ubilab/result/service/ResultServiceSpec.scala
@@ -37,7 +37,6 @@ class ResultServiceSpec extends FunSpec with Matchers {
     }
 
     it("devrait avoir une liste de 1 résultat vue aprés la vision de ce résultat") {
-      pending
       resultService.seenResult(46)
       resultService.getAllResultSeen().length shouldEqual 1
       resultService.getAllResult().head.isSeen shouldEqual true

--- a/src/test/scala/io/ubilab/result/service/ResultServiceSpec.scala
+++ b/src/test/scala/io/ubilab/result/service/ResultServiceSpec.scala
@@ -78,9 +78,11 @@ class ResultServiceSpec extends FunSpec with Matchers {
       resultService.getAllResultSeen.length shouldEqual 3
     }
 
-    it("devrait avoir plus que 2 résultats vue dans la liste après qu'il soit tous vue puis 1 ou la vue est enlevé") {
-      pending
-      true shouldEqual false
+    it("devrait n'avoir plus que 2 résultats vus dans la liste après qu'ils soient tous vus puis 1 ou la vue est enlevée") {
+      resultService.getAllResultSeen.length shouldEqual 3
+      resultService.unseenResult(result_1.id)
+      resultService.getAllResultSeen.length shouldEqual 2
+
     }
 
     it("ne devrait pas planter après la vision d\\'un résultat non ajouté") {

--- a/src/test/scala/io/ubilab/result/service/ResultServiceSpec.scala
+++ b/src/test/scala/io/ubilab/result/service/ResultServiceSpec.scala
@@ -64,9 +64,9 @@ class ResultServiceSpec extends FunSpec with Matchers {
       resultService.addResult(a_result.copy(id = a_result.id)) shouldBe a[Failure[_]] // sameness of id is explicit!
     }
 
-    it("devrait avoir 1 résultats vue dans la liste après la vision d'un résultat") {
-      pending
-      true shouldEqual false
+    it("devrait avoir 1 résultat vu dans la liste après la vision d'un résultat") {
+      resultService.seenResult(46)
+      resultService.getAllResultSeen.length shouldEqual 1
     }
 
     it("devrait avoir les 3 résultats vue dans la liste après qu'il soit tous vue") {

--- a/src/test/scala/io/ubilab/result/service/ResultServiceSpec.scala
+++ b/src/test/scala/io/ubilab/result/service/ResultServiceSpec.scala
@@ -61,7 +61,7 @@ class ResultServiceSpec extends FunSpec with Matchers {
     }
 
     it("ne devrait pas autoriser l'ajout d'un résultat avec un id existant") {
-      resultService.addResult(a_result.copy(id = a_result.id)) shouldBe a[Failure[_]]
+      resultService.addResult(a_result.copy(id = a_result.id)) shouldBe a[Failure[_]] // sameness of id is explicit!
     }
 
     it("devrait avoir 1 résultats vue dans la liste après la vision d'un résultat") {

--- a/src/test/scala/io/ubilab/result/service/ResultServiceSpec.scala
+++ b/src/test/scala/io/ubilab/result/service/ResultServiceSpec.scala
@@ -61,7 +61,7 @@ class ResultServiceSpec extends FunSpec with Matchers {
     }
 
     it("ne devrait pas autoriser l'ajout d'un résultat avec un id existant") {
-      resultService.addResult(a_result.copy(id = a_result.id)) shouldBe a[Failure[ListBuffer[Result]]]
+      resultService.addResult(a_result.copy(id = a_result.id)) shouldBe a[Failure[_]]
     }
 
     it("devrait avoir 1 résultats vue dans la liste après la vision d'un résultat") {

--- a/src/test/scala/io/ubilab/result/service/ResultServiceSpec.scala
+++ b/src/test/scala/io/ubilab/result/service/ResultServiceSpec.scala
@@ -18,7 +18,7 @@ class ResultServiceSpec extends FunSpec with Matchers {
     }
   }
 
-  describe("Après l'ajout d'un résultat,") {
+  describe("Step 2 : Après l'ajout d'un résultat,") {
 
     val resultService = ResultService.build
 
@@ -47,7 +47,7 @@ class ResultServiceSpec extends FunSpec with Matchers {
 
   }
 
-  describe("Après l'ajout de 3 résultats,") {
+  describe("Step 3 : Après l'ajout de 3 résultats,") {
 
     // init le service avec 3 résultats
     val resultService = ResultService.build
@@ -86,14 +86,14 @@ class ResultServiceSpec extends FunSpec with Matchers {
     }
 
     it("ne devrait pas planter après la vision d\\'un résultat non ajouté") {
-      pending
-      true shouldEqual false
+      val notAddedResult = result_1.copy(id = result_1.id + 42)
+      noException should be thrownBy resultService.seenResult(notAddedResult.id)
     }
 
   }
 
 
-  describe("Après l'ajout de 3 résultats,") {
+  describe("Step 4 : Après l'ajout de 3 résultats (events)") {
     pending
     // init le service avec 3 résultats
     it("devrait avoir la list des résultat dans l'order de création ( en se basant sur les events de création)") {

--- a/src/test/scala/io/ubilab/result/service/ResultServiceSpec.scala
+++ b/src/test/scala/io/ubilab/result/service/ResultServiceSpec.scala
@@ -45,30 +45,33 @@ class ResultServiceSpec extends FunSpec with Matchers {
   }
 
   describe("Après l'ajout de 3 résultats,") {
-    pending
-    // init le service avec 3 resultats
 
     it("devrait avoir une liste de 3 resultats non vue aprés l'ajout de 3 resultat.") {
       true shouldEqual false
     }
 
-    it("ne devrait pas authorisé l'ajout d'un résultats avec un id existant") {
+    it("ne devrait pas autoriser l'ajout d'un résultats avec un id existant") {
+      pending
       true shouldEqual false
     }
 
-    it("devrait avoir 1 resultats vue dans la liste aprés la vision d'un resultat") {
+    it("devrait avoir 1 résultats vue dans la liste après la vision d'un résultat") {
+      pending
       true shouldEqual false
     }
 
-    it("devrait avoir les 3 resultats vue dans la liste aprés qu'il soit tous vue") {
+    it("devrait avoir les 3 résultats vue dans la liste après qu'il soit tous vue") {
+      pending
       true shouldEqual false
     }
 
-    it("devrait avoir plus que 2 resultats vue dans la liste aprés qu'il soit tous vue puis 1 ou la vue est enlevé") {
+    it("devrait avoir plus que 2 résultats vue dans la liste après qu'il soit tous vue puis 1 ou la vue est enlevé") {
+      pending
       true shouldEqual false
     }
 
-    it("ne devrait pas planté aprés la vision d\\'un resultat non ajouté") {
+    it("ne devrait pas planter après la vision d\\'un résultat non ajouté") {
+      pending
       true shouldEqual false
     }
 
@@ -77,7 +80,7 @@ class ResultServiceSpec extends FunSpec with Matchers {
 
   describe("Après l'ajout de 3 résultats,") {
     pending
-    // init le service avec 3 resultats
+    // init le service avec 3 résultats
     it("devrait avoir la list des résultat dans l'order de création ( en se basant sur les events de création)") {
       true shouldEqual false
     }
@@ -86,11 +89,11 @@ class ResultServiceSpec extends FunSpec with Matchers {
       true shouldEqual false
     }
 
-    it("devrait avoir 2 events avec 2 dates différent aprés la vision d'un resultat puis la suppression de la vision") {
+    it("devrait avoir 2 events avec 2 dates différent après la vision d'un résultat puis la suppression de la vision") {
       true shouldEqual false
     }
 
-    it("devrait avoir une fonction qui retourne une liste ordonnée des resultats par rapport au dernier modifier") {
+    it("devrait avoir une fonction qui retourne une liste ordonnée des résultats par rapport au dernier modifier") {
       true shouldEqual false
     }
   }

--- a/src/test/scala/io/ubilab/result/service/ResultServiceSpec.scala
+++ b/src/test/scala/io/ubilab/result/service/ResultServiceSpec.scala
@@ -69,9 +69,11 @@ class ResultServiceSpec extends FunSpec with Matchers {
       resultService.getAllResultSeen.length shouldEqual 1
     }
 
-    it("devrait avoir les 3 résultats vue dans la liste après qu'il soit tous vue") {
-      pending
-      true shouldEqual false
+    it("devrait avoir les 3 résultats vus dans la liste après qu'ils soient tous vus.") {
+      resultService.seenResult(46)
+      resultService.seenResult(47)
+      resultService.seenResult(48)
+      resultService.getAllResultSeen.length shouldEqual 3
     }
 
     it("devrait avoir plus que 2 résultats vue dans la liste après qu'il soit tous vue puis 1 ou la vue est enlevé") {


### PR DESCRIPTION
Step 3 : Après l'ajout de 3 résultats,

- devrait avoir une liste de 3 résultats non vus après l'ajout de 3 résultats
- ne devrait pas autoriser l'ajout d'un résultat avec un id existant
- devrait avoir 1 résultat vu dans la liste après la vision d'un résultat
- devrait avoir les 3 résultats vus dans la liste après qu'ils soient tous vus
- ne devrait pas planter après la vision d'un résultat non ajouté